### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -21,7 +21,7 @@ jobs:
             version_number: ${{ steps.release_metadata.outputs.version_number }}
             changelog: ${{ steps.release_metadata.outputs.changelog }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.1.1
+            -   uses: apify/actions/git-cliff-release@v1.1.2
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -21,7 +21,7 @@ jobs:
             version_number: ${{ steps.release_metadata.outputs.version_number }}
             changelog: ${{ steps.release_metadata.outputs.changelog }}
         steps:
-            -   uses: apify/workflows/git-cliff-release@main
+            -   uses: apify/actions/git-cliff-release@v1.0.0
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -21,7 +21,7 @@ jobs:
             version_number: ${{ steps.release_metadata.outputs.version_number }}
             changelog: ${{ steps.release_metadata.outputs.changelog }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.0.0
+            -   uses: apify/actions/git-cliff-release@v1.1.0
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -21,7 +21,7 @@ jobs:
             version_number: ${{ steps.release_metadata.outputs.version_number }}
             changelog: ${{ steps.release_metadata.outputs.changelog }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.1.0
+            -   uses: apify/actions/git-cliff-release@v1.1.1
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            -   uses: apify/workflows/git-cliff-release@main
+            -   uses: apify/actions/git-cliff-release@v1.0.0
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.1.1
+            -   uses: apify/actions/git-cliff-release@v1.1.2
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.0.0
+            -   uses: apify/actions/git-cliff-release@v1.1.0
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.1.0
+            -   uses: apify/actions/git-cliff-release@v1.1.1
                 name: Prepare release metadata
                 id: release_metadata
                 with:


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.